### PR TITLE
timeframe(s)

### DIFF
--- a/linter/rules/dimension_group_of_type_time_requires_timeframe.py
+++ b/linter/rules/dimension_group_of_type_time_requires_timeframe.py
@@ -3,10 +3,12 @@ from linter.rule import Rule
 
 class DimensionGroupOfTypeTimeRequiresTimeframe(Rule):
     def applies_to():
-        return ('dimension_group',)
+        return ("dimension_group",)
 
     def run(self, dimension_group):
-        type = dimension_group.get('type')
-        if type == 'time' and not 'timeframe' in dimension_group:
+        type = dimension_group.get("type")
+        if type == "time" and (
+            not "timeframe" in dimension_group and not "timeframes" in dimension_group
+        ):
             return False
         return True


### PR DESCRIPTION
We often use `timeframes` instead of `timeframe` to specify multiple possible timeframes for slicing time dimension groups.